### PR TITLE
Wait for check if its status is "queued"

### DIFF
--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -36,8 +36,8 @@ if current_status.nil?
   exit(false)
 end
 
-while current_status == "in_progress"
-  puts "Requested check is still in progress, will check back in #{wait} seconds..."
+while current_status == "queued" || current_status == "in_progress"
+  puts "The requested check hasn't completed yet, will check back in #{wait} seconds..."
   sleep(wait)
   current_status, conclusion = query_check_status(ref, check_name, token)
 end


### PR DESCRIPTION
The action shouldn't fail if the check that is being waited for is found but hasn't started yet. 