### PR TITLE
allow omitting check name to wait for all checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v0.1
         with:
           ref: master # can be commit SHA or tag too
-          check-name: test # name of the existing check
+          check-name: test # name of the existing check - omit to wait for all checks
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20 # seconds
 


### PR DESCRIPTION
My attempt at addressing #4 

My first try at ruby so I'm fully expecting some glaring errors 🙂 however I have tested it locally and it seems to work 👍 

The status check endpoint can return all checks if the check_name is omitted, so I took advantage of that and made the rest of the program operate agnostically on an array of checks.

One thing I'm definitely unsure about is omitting the arg - specifically with the integration with GitHub actions. Testing locally, I pass `""` in place of the check name, and this works, I'm just not sure if that's how it'll be passed if the check name is omitted from the github action/workflow config.