### PR TITLE
Make the GitHub token optional since it's not needed for public repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,11 @@ inputs:
     default: ""
   repo-token:
     description: "A GitHub token for the repo"
-    required: true
+    required: false
+    default: ""
   wait-interval:
     description: "Seconds to wait between Checks API requests"
-    required: true
+    required: false
     default: "10"
 runs:
   using: "docker"

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -11,7 +11,7 @@ def query_check_status(ref, check_name, token)
   }")
   request = Net::HTTP::Get.new(uri)
   request["Accept"] = "application/vnd.github.antiope-preview+json"
-  request["Authorization"] = "token #{token}"
+  token.empty? || request["Authorization"] = "token #{token}"
   req_options = {
     use_ssl: uri.scheme == "https"
   }


### PR DESCRIPTION
The token's always available where this is invoked, but as a best practice we can avoid passing it around unless we actually need it (and we don't need it for public repos).

Also mark wait-interval as optional since it has a default value.