### PR TITLE
Fix/ignore invoking workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,29 @@ There are two variables to have in mind:
 
 The first one is optional. If provided, the second one is not needed.
 If none of them is given, the check will wait "forever" because it will be waiting for itself to finish.
+
+Example:
+
+```yml
+name: Waiting for checks and deploy
+
+on:
+  push:
+
+jobs:
+  deploy: # This name is the one to be used in `running-workflow-name`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Wait on tests
+        uses: lewagon/wait-on-check-action@master
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: 'deploy' # HERE
+
+      - name: Step to deploy
+        run: echo 'success!'
+```
+

--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ jobs:
 ```
 
 :point_up: Name is `My test workflow`
+
+
+### Waiting for a specific check to finish OR waiting for all checks to finish
+
+There are two variables to have in mind:
+- `check-name`: Name of the check we want to wait to finish before continuing.
+- `running-workflow-name`: Name of the check that will wait for the rest.
+
+The first one is optional. If provided, the second one is not needed.
+If none of them is given, the check will wait "forever" because it will be waiting for itself to finish.

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: "10"
   running-workflow-name:
-    description: "Workflow that is waiting for the others"
+    description: "Name of the workflow to be ignored (the one who is waiting for the rest)"
     required: false
-    default: ${{ github.action }}
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,6 @@ inputs:
     description: "Seconds to wait between Checks API requests"
     required: false
     default: "10"
-  running-workflow-name:
-    description: "Workflow that is waiting for the others"
-    required: false
-    default: ${{ github.action }}
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -30,7 +26,7 @@ runs:
     - ${{ inputs.check-name }}
     - ${{ inputs.repo-token }}
     - ${{ inputs.wait-interval }}
-    - ${{ inputs.running-workflow-name }}
+    - ${{ github.action }}
 branding:
   icon: "check-circle"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Seconds to wait between Checks API requests"
     required: false
     default: "10"
+  running-workflow-name:
+    description: "Workflow that is waiting for the others"
+    required: false
+    default: ${{ github.action }}
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -26,7 +30,7 @@ runs:
     - ${{ inputs.check-name }}
     - ${{ inputs.repo-token }}
     - ${{ inputs.wait-interval }}
-    - ${{ github.action }}
+    - ${{ inputs.running-workflow-name }}
 branding:
   icon: "check-circle"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Seconds to wait between Checks API requests"
     required: false
     default: "10"
+  running-workflow-name:
+    description: "Workflow that is waiting for the others"
+    required: false
+    default: ${{ github.action }}
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -26,6 +30,7 @@ runs:
     - ${{ inputs.check-name }}
     - ${{ inputs.repo-token }}
     - ${{ inputs.wait-interval }}
+    - ${{ inputs.running-workflow-name }}
 branding:
   icon: "check-circle"
   color: "green"

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -29,7 +29,7 @@ end
 
 # check_name is the name of the "job" key in a workflow, or the full name if the "name" key
 # is provided for job. Probably, the "name" key should be kept empty to keep things short
-ref, check_name, token, wait = ARGV
+ref, check_name, token, wait, workflow_name = ARGV
 wait = wait.to_i
 all_checks = query_check_status(ref, check_name, token)
 
@@ -38,7 +38,8 @@ if !check_name.empty? && all_checks.empty?
   exit(false)
 end
 
-all_complete = all_checks_complete(all_checks)
+all_other_checks = all_checks.reject{|check| check['name'] == workflow_name}
+all_complete = all_checks_complete(all_other_checks)
 
 until all_complete
   plural_part = all_checks.length > 1 ? "checks aren't" : "check isn't"

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -5,7 +5,7 @@ require "json"
 
 REPO = ENV["GITHUB_REPOSITORY"]
 
-def query_check_status(ref, check_name, token)
+def query_check_status(ref, check_name, token, workflow_name)
   uri = URI.parse("https://api.github.com/repos/#{REPO}/commits/#{ref}/check-runs#{
     "?check_name=#{check_name}" unless check_name.empty?
   }")
@@ -31,7 +31,7 @@ end
 # is provided for job. Probably, the "name" key should be kept empty to keep things short
 ref, check_name, token, wait, workflow_name = ARGV
 wait = wait.to_i
-all_checks = query_check_status(ref, check_name, token)
+all_checks = query_check_status(ref, check_name, token, workflow_name)
 
 if !check_name.empty? && all_checks.empty?
   puts "The requested check was never run against this ref, exiting..."
@@ -42,7 +42,7 @@ until all_checks_complete(all_checks)
   plural_part = all_other_checks.length > 1 ? "checks aren't" : "check isn't"
   puts "The requested #{plural_part} complete yet, will check back in #{wait} seconds..."
   sleep(wait)
-  all_checks = query_check_status(ref, check_name, token)
+  all_checks = query_check_status(ref, check_name, token, workflow_name)
 end
 
 puts "Checks completed:"

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -20,7 +20,7 @@ def query_check_status(ref, check_name, token)
   }
   parsed = JSON.parse(response.body)
 
-  parsed["check_runs"]
+  parsed["check_runs"].reject { |check| check['name'] == workflow_name }
 end
 
 def all_checks_complete(checks)
@@ -38,16 +38,11 @@ if !check_name.empty? && all_checks.empty?
   exit(false)
 end
 
-all_other_checks = all_checks.reject{|check| check['name'] == workflow_name}
-puts "The workflow #{workflow_name} is waiting for the following checks to finish: #{all_other_checks.map{|check| check['name']}.join(', ')}"
-all_complete = all_checks_complete(all_other_checks)
-
-until all_complete
-  plural_part = all_checks.length > 1 ? "checks aren't" : "check isn't"
+until all_checks_complete(all_checks)
+  plural_part = all_other_checks.length > 1 ? "checks aren't" : "check isn't"
   puts "The requested #{plural_part} complete yet, will check back in #{wait} seconds..."
   sleep(wait)
   all_checks = query_check_status(ref, check_name, token)
-  all_complete = all_checks_complete(all_checks)
 end
 
 puts "Checks completed:"

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -39,6 +39,7 @@ if !check_name.empty? && all_checks.empty?
 end
 
 all_other_checks = all_checks.reject{|check| check['name'] == workflow_name}
+puts "The workflow #{workflow_name} is waiting for the following checks to finish: #{all_other_checks.map{|check| check['name']}.join(', ')}"
 all_complete = all_checks_complete(all_other_checks)
 
 until all_complete


### PR DESCRIPTION
This PR solves this issue: https://github.com/lewagon/wait-on-check-action/issues/7

The problem seemed to be that the check was waiting for itself to finish when omitting the `check-name` parameter.

I added a new argument to be able to filter out the invoking workflow from the checks to wait.
I couldn't find a way to extract it from the Github context. If anybody knows, that would be a cleaner solution.