### PR TITLE
Add a test workflow to test allowed-conclusions

### DIFF
--- a/.github/workflows/wait-for-allowed-conclusions.yml
+++ b/.github/workflows/wait-for-allowed-conclusions.yml
@@ -1,0 +1,28 @@
+name: Wait using allowed_conclusions
+on:
+  workflow_dispatch:
+
+jobs:
+  skipped_job:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - name: Should not be executed
+        run: echo 'should not be executed'
+
+  wait-for-skipped-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Wait on tests
+        uses: ./
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          running-workflow-name: wait-for-skipped-job
+          check-name: 'skipped_job'
+          allowed-conclusions: ['skipped']
+
+      - name: Success
+        run: echo 'success!'


### PR DESCRIPTION
This workflow should fail right now but succeed with [these changes](https://github.com/lewagon/wait-on-check-action/pull/20).

Would be great if @Billy- could rebase master when this workflow is merged, so we can have the check to run using the new feature.