### PR TITLE
Dev/add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,25 +3,8 @@
 require: rubocop-rspec
 AllCops:
   Exclude:
-    - 'spec/spec_helper.rb'
+    - 'app/spec/spec_helper.rb'
     - 'Gemfile'
-
-RSpec/BeforeAfterAll:
-  Enabled: true
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - 'spec/**/*.rb'
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*.rb'
 
 Layout/LineLength:
   Max: 120
@@ -30,8 +13,28 @@ Layout/LineLength:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
-Style/Documentation:
+Metrics/BlockLength:
+  Exclude:
+    - 'app/spec/**/*.rb'
+
+RSpec/BeforeAfterAll:
+  Enabled: true
+
+RSpec/DescribeClass:
   Enabled: false
 
 RSpec/EmptyLineAfterFinalLet:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'app/spec/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,37 @@
+# This is the configuration used to check the rubocop source code.
+
+require: rubocop-rspec
+AllCops:
+  Exclude:
+    - 'spec/spec_helper.rb'
+    - 'Gemfile'
+
+RSpec/BeforeAfterAll:
+  Enabled: true
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Layout/LineLength:
+  Max: 120
+  IgnoredPatterns: ['(\A|\s)#']
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update -yqq && apt-get -yqq --no-install-recommends install build-es
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 RUN gem install bundler
-RUN bundle config set with 'development test'
 RUN bundle install --jobs 20 --retry 5
 COPY app /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'activesupport', '~> 6.1.1'
 
 group :test, :development do
   gem 'rspec'
+  gem 'rubocop-rspec', require: false
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
@@ -24,7 +25,13 @@ GEM
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     public_suffix (4.0.6)
+    rainbow (3.0.0)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -38,12 +45,28 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    rubocop (1.9.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -54,6 +77,7 @@ DEPENDENCIES
   byebug
   octokit (~> 4.20)
   rspec
+  rubocop-rspec
 
 BUNDLED WITH
    2.2.3

--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-require_relative "./application_service"
-require "active_support/configurable"
+require_relative './application_service'
+require 'active_support/configurable'
 
-require "json"
-require "octokit"
+require 'json'
+require 'octokit'
 
 class GithubChecksVerifier < ApplicationService
   include ActiveSupport::Configurable
   config_accessor :check_name, :workflow_name, :client, :repo, :ref
   config_accessor(:wait) { 30 } # set a default
-  config_accessor(:check_regexp) { "" }
-  config_accessor(:allowed_conclusions) { ["success", "skipped"] }
+  config_accessor(:check_regexp) { '' }
+  config_accessor(:allowed_conclusions) { %w[success skipped] }
 
   def call
     wait_for_checks
-  rescue => e
+  rescue StandardError => e
     puts e.message
     exit(false)
   end
 
   def query_check_status
-    checks = client.check_runs_for_ref(repo, ref, {accept: "application/vnd.github.antiope-preview+json"}).check_runs
+    checks = client.check_runs_for_ref(repo, ref, { accept: 'application/vnd.github.antiope-preview+json' }).check_runs
     p checks # DEBUG
     apply_filters(checks)
   end
@@ -39,7 +39,7 @@ class GithubChecksVerifier < ApplicationService
   end
 
   def all_checks_complete(checks)
-    checks.all? { |check| check.status == "completed" }
+    checks.all? { |check| check.status == 'completed' }
   end
 
   def filters_present?
@@ -53,7 +53,7 @@ class GithubChecksVerifier < ApplicationService
   def fail_if_requested_check_never_run(check_name, all_checks)
     return unless check_name.present? && all_checks.blank?
 
-    raise StandardError, "The requested check was never run against this ref, exiting..."
+    raise StandardError, 'The requested check was never run against this ref, exiting...'
   end
 
   def fail_unless_all_conclusions_allowed(checks)
@@ -63,8 +63,8 @@ class GithubChecksVerifier < ApplicationService
   end
 
   def show_checks_conclusion_message(checks)
-    puts "Checks completed:"
-    puts checks.reduce("") { |message, check|
+    puts 'Checks completed:'
+    puts checks.reduce('') { |message, check|
       "#{message}#{check.name}: #{check.status} (#{check.conclusion})\n"
     }
   end

--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -3,9 +3,6 @@
 require_relative './application_service'
 require 'active_support/configurable'
 
-require 'json'
-require 'octokit'
-
 class GithubChecksVerifier < ApplicationService
   include ActiveSupport::Configurable
   config_accessor :check_name, :workflow_name, :client, :repo, :ref

--- a/app/spec/entrypoint_spec.rb
+++ b/app/spec/entrypoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'entrypoint' do

--- a/app/spec/entrypoint_spec.rb
+++ b/app/spec/entrypoint_spec.rb
@@ -1,12 +1,11 @@
-require "spec_helper"
+require 'spec_helper'
 
-
-describe "entrypoint" do
-  it "calls the GithubChecksVerifier service" do
+describe 'entrypoint' do
+  it 'calls the GithubChecksVerifier service' do
     allow(GithubChecksVerifier).to receive(:call)
     allow(GithubChecksVerifier).to receive(:configure)
 
-    require_relative "../../entrypoint.rb"
+    require_relative '../../entrypoint'
 
     expect(GithubChecksVerifier).to have_received(:call)
   end

--- a/app/spec/services/github_checks_verifier_spec.rb
+++ b/app/spec/services/github_checks_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'ostruct'
 
@@ -23,7 +25,7 @@ describe GithubChecksVerifier do
     it 'waits until all checks are completed' do
       cycles = 1 # simulates the method waiting for one cyecle
       allow(service).to receive(:all_checks_complete) do
-        (cycles -= 1) && cycles < 0
+        (cycles -= 1) && cycles.negative?
       end
 
       all_successful_checks = load_checks_from_yml('all_checks_successfully_completed.json')

--- a/app/spec/services/github_checks_verifier_spec.rb
+++ b/app/spec/services/github_checks_verifier_spec.rb
@@ -1,5 +1,5 @@
-require "spec_helper"
-require "ostruct"
+require 'spec_helper'
+require 'ostruct'
 
 describe GithubChecksVerifier do
   let(:service) do
@@ -8,162 +8,163 @@ describe GithubChecksVerifier do
 
   before do
     described_class.config.client = Octokit::Client.new
-    described_class.config.allowed_conclusions = ["success", "skipped"]
+    described_class.config.allowed_conclusions = %w[success skipped]
   end
 
-  describe "#call" do
-    before { allow(service).to receive(:wait_for_checks).and_raise(StandardError, "test error") }
+  describe '#call' do
+    before { allow(service).to receive(:wait_for_checks).and_raise(StandardError, 'test error') }
 
-    it "exit with status false if wait_for_checks fails" do
+    it 'exit with status false if wait_for_checks fails' do
       expect { with_captured_stdout { service.call } }.to raise_error(SystemExit)
     end
   end
 
-  describe "#wait_for_checks" do
-    it "waits until all checks are completed" do
+  describe '#wait_for_checks' do
+    it 'waits until all checks are completed' do
       cycles = 1 # simulates the method waiting for one cyecle
       allow(service).to receive(:all_checks_complete) do
         (cycles -= 1) && cycles < 0
       end
 
-      all_successful_checks = load_checks_from_yml("all_checks_successfully_completed.json")
+      all_successful_checks = load_checks_from_yml('all_checks_successfully_completed.json')
       mock_api_response(all_successful_checks)
-      service.workflow_name = "invoking_check"
+      service.workflow_name = 'invoking_check'
       service.wait = 0
-      output = with_captured_stdout{ service.wait_for_checks }
+      output = with_captured_stdout { service.wait_for_checks }
 
       expect(output).to include("The requested check isn't complete yet, will check back in #{service.wait} seconds...")
     end
   end
 
-  describe "#all_checks_complete" do
-    it "returns true if all checks are in status complete" do
+  describe '#all_checks_complete' do
+    it 'returns true if all checks are in status complete' do
       expect(service.all_checks_complete(
-        [
-          OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
-          OpenStruct.new(name: "test", status: "completed", conclusion: "failure")
-        ]
-      )).to be true
+               [
+                 OpenStruct.new(name: 'test', status: 'completed', conclusion: 'success'),
+                 OpenStruct.new(name: 'test', status: 'completed', conclusion: 'failure')
+               ]
+             )).to be true
     end
 
-    context "some checks (apart from the invoking one) are not complete" do
-      it "false if some check still queued" do
+    context 'some checks (apart from the invoking one) are not complete' do
+      it 'false if some check still queued' do
         expect(service.all_checks_complete(
-          [
-            OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
-            OpenStruct.new(name: "test", status: "queued", conclusion: nil)
-          ]
-        )).to be false
+                 [
+                   OpenStruct.new(name: 'test', status: 'completed', conclusion: 'success'),
+                   OpenStruct.new(name: 'test', status: 'queued', conclusion: nil)
+                 ]
+               )).to be false
       end
 
-      it "false if some check is in progress" do
+      it 'false if some check is in progress' do
         expect(service.all_checks_complete(
-          [
-            OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
-            OpenStruct.new(name: "test", status: "in_progress", conclusion: nil)
-          ]
-        )).to be false
+                 [
+                   OpenStruct.new(name: 'test', status: 'completed', conclusion: 'success'),
+                   OpenStruct.new(name: 'test', status: 'in_progress', conclusion: nil)
+                 ]
+               )).to be false
       end
     end
   end
 
-  describe "#query_check_status" do
-    it "filters out the invoking check" do
-      all_checks = load_checks_from_yml("all_checks_results.json")
+  describe '#query_check_status' do
+    it 'filters out the invoking check' do
+      all_checks = load_checks_from_yml('all_checks_results.json')
       mock_api_response(all_checks)
 
-      service.config.workflow_name = "invoking_check"
+      service.config.workflow_name = 'invoking_check'
 
       result = service.query_check_status
 
-      expect(result.map(&:name)).not_to include("invoking_check")
+      expect(result.map(&:name)).not_to include('invoking_check')
     end
   end
 
-  describe "#fail_if_requested_check_never_run" do
-    it "raises an exception if check_name is not empty and all_checks is" do
+  describe '#fail_if_requested_check_never_run' do
+    it 'raises an exception if check_name is not empty and all_checks is' do
       check_name = 'test'
       all_checks = []
 
       expect do
         service.fail_if_requested_check_never_run(check_name, all_checks)
-      end.to raise_error(StandardError, "The requested check was never run against this ref, exiting...")
+      end.to raise_error(StandardError, 'The requested check was never run against this ref, exiting...')
     end
   end
 
-  describe "#fail_unless_all_conclusions_allowed" do
-    it "raises an exception if some check conclusion is not allowed" do
+  describe '#fail_unless_all_conclusions_allowed' do
+    it 'raises an exception if some check conclusion is not allowed' do
       all_checks = [
-        OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
-        OpenStruct.new(name: "test", status: "completed", conclusion: "failure")
+        OpenStruct.new(name: 'test', status: 'completed', conclusion: 'success'),
+        OpenStruct.new(name: 'test', status: 'completed', conclusion: 'failure')
       ]
 
       expect do
         service.fail_unless_all_conclusions_allowed(all_checks)
-      end.to raise_error(StandardError, 'The conclusion of one or more checks were not allowed. Allowed conclusions are: success, skipped. This can be configured with the \'allowed-conclusions\' param.')
+      end.to raise_error(StandardError,
+                         'The conclusion of one or more checks were not allowed. Allowed conclusions are: success, skipped. This can be configured with the \'allowed-conclusions\' param.')
     end
 
-    it "does not raise an exception if all checks conlusions are allowed" do
+    it 'does not raise an exception if all checks conlusions are allowed' do
       all_checks = [
-        OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
-        OpenStruct.new(name: "test", status: "completed", conclusion: "skipped")
+        OpenStruct.new(name: 'test', status: 'completed', conclusion: 'success'),
+        OpenStruct.new(name: 'test', status: 'completed', conclusion: 'skipped')
       ]
-  
+
       expect do
         service.fail_unless_all_conclusions_allowed(all_checks)
       end.not_to raise_error
     end
   end
 
-  describe "#show_checks_conclusion_message" do
-    it "prints successful message to standard output" do
-      checks = [OpenStruct.new(name: "check_completed", status: "completed", conclusion: "success")]
-      output = with_captured_stdout{ service.show_checks_conclusion_message(checks) }
+  describe '#show_checks_conclusion_message' do
+    it 'prints successful message to standard output' do
+      checks = [OpenStruct.new(name: 'check_completed', status: 'completed', conclusion: 'success')]
+      output = with_captured_stdout { service.show_checks_conclusion_message(checks) }
 
-      expect(output).to include("check_completed: completed (success)")
+      expect(output).to include('check_completed: completed (success)')
     end
   end
 
-  describe "#apply_filters" do
-    it "filters out all but check_name" do
+  describe '#apply_filters' do
+    it 'filters out all but check_name' do
       checks = [
-        OpenStruct.new(name: "check_name", status: "queued"),
-        OpenStruct.new(name: "other_check", status: "queued")
+        OpenStruct.new(name: 'check_name', status: 'queued'),
+        OpenStruct.new(name: 'other_check', status: 'queued')
       ]
 
-      service.config.check_name = "check_name"
+      service.config.check_name = 'check_name'
       service.apply_filters(checks)
-      expect(checks.map(&:name)).to all( eq "check_name" )
+      expect(checks.map(&:name)).to all(eq 'check_name')
     end
 
     it "does not filter by check_name if it's empty" do
       checks = [
-        OpenStruct.new(name: "check_name", status: "queued"),
-        OpenStruct.new(name: "other_check", status: "queued")
+        OpenStruct.new(name: 'check_name', status: 'queued'),
+        OpenStruct.new(name: 'other_check', status: 'queued')
       ]
 
-      service.config.check_name = ""
+      service.config.check_name = ''
       allow(service).to receive(:apply_regexp_filter).with(checks).and_return(checks)
       service.apply_filters(checks)
 
       expect(checks.size).to eq 2
     end
 
-    it "filters out the workflow_name" do
+    it 'filters out the workflow_name' do
       checks = [
-        OpenStruct.new(name: "workflow_name", status: "pending"),
-        OpenStruct.new(name: "other_check", status: "queued")
+        OpenStruct.new(name: 'workflow_name', status: 'pending'),
+        OpenStruct.new(name: 'other_check', status: 'queued')
       ]
-      service.config.workflow_name = "workflow_name"
+      service.config.workflow_name = 'workflow_name'
       service.apply_filters(checks)
 
-      expect(checks.map(&:name)).not_to include("workflow_name")
+      expect(checks.map(&:name)).not_to include('workflow_name')
     end
 
-    it "apply the regexp filter" do
+    it 'apply the regexp filter' do
       checks = [
-        OpenStruct.new(name: "test", status: "pending"),
-        OpenStruct.new(name: "test", status: "queued")
+        OpenStruct.new(name: 'test', status: 'pending'),
+        OpenStruct.new(name: 'test', status: 'queued')
       ]
       allow(service).to receive(:apply_regexp_filter)
       service.apply_filters(checks)
@@ -174,31 +175,31 @@ describe GithubChecksVerifier do
     end
   end
 
-  describe "#apply_regexp_filter" do
-    it "simple regexp" do
+  describe '#apply_regexp_filter' do
+    it 'simple regexp' do
       checks = [
-        OpenStruct.new(name: "check_name", status: "queued"),
-        OpenStruct.new(name: "other_check", status: "queued")
+        OpenStruct.new(name: 'check_name', status: 'queued'),
+        OpenStruct.new(name: 'other_check', status: 'queued')
       ]
 
       service.check_regexp = Regexp.new('._check')
       service.apply_regexp_filter(checks)
 
-      expect(checks.map(&:name)).to include("other_check")
-      expect(checks.map(&:name)).not_to include("check_name")
+      expect(checks.map(&:name)).to include('other_check')
+      expect(checks.map(&:name)).not_to include('check_name')
     end
 
-    it "complex regexp" do
+    it 'complex regexp' do
       checks = [
-        OpenStruct.new(name: "test@example.com", status: "queued"),
-        OpenStruct.new(name: "other_check", status: "queued")
+        OpenStruct.new(name: 'test@example.com', status: 'queued'),
+        OpenStruct.new(name: 'other_check', status: 'queued')
       ]
 
       service.check_regexp = Regexp.new('\A[\w.+-]+@\w+\.\w+\z')
       service.apply_regexp_filter(checks)
 
-      expect(checks.map(&:name)).not_to include("other_check")
-      expect(checks.map(&:name)).to include("test@example.com")
+      expect(checks.map(&:name)).not_to include('other_check')
+      expect(checks.map(&:name)).to include('test@example.com')
     end
   end
 end

--- a/app/spec/support/helpers.rb
+++ b/app/spec/support/helpers.rb
@@ -13,11 +13,6 @@ module Helpers
     JSON.parse(load_json_sample(yml_file))['check_runs'].map { |check| OpenStruct.new(check) }
   end
 
-  def mock_api_response(checks)
-    response = double(check_runs: checks)
-    allow_any_instance_of(Octokit::Client).to receive(:check_runs_for_ref) { response }
-  end
-
   def with_captured_stdout
     original_stdout = $stdout  # capture previous value of $stdout
     $stdout = StringIO.new     # assign a string buffer to $stdout

--- a/app/spec/support/helpers.rb
+++ b/app/spec/support/helpers.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-require "ostruct"
-require "json"
+
+require 'ostruct'
+require 'json'
 module Helpers
-  SAMPLE_RESPONSES_BASE_PATH = "spec/github_api_sample_responses/"
+  SAMPLE_RESPONSES_BASE_PATH = 'spec/github_api_sample_responses/'
 
   def load_json_sample(file_name)
     File.read(SAMPLE_RESPONSES_BASE_PATH + file_name)
   end
 
   def load_checks_from_yml(yml_file)
-    JSON.parse(load_json_sample(yml_file))["check_runs"].map { |check| OpenStruct.new(check) }
+    JSON.parse(load_json_sample(yml_file))['check_runs'].map { |check| OpenStruct.new(check) }
   end
 
   def mock_api_response(checks)

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-require_relative "./app/services/github_checks_verifier.rb"
-require "octokit"
+require_relative './app/services/github_checks_verifier'
+require 'octokit'
 
 ref, check_name, check_regexp, token, wait, workflow_name, allowed_conclusions = ARGV
 
@@ -9,7 +9,7 @@ GithubChecksVerifier.configure do |config|
   config.check_regexp = check_regexp
   config.client = Octokit::Client.new(access_token: token)
   config.ref = ref
-  config.repo = ENV["GITHUB_REPOSITORY"]
+  config.repo = ENV['GITHUB_REPOSITORY']
   config.wait = wait.to_i
   config.workflow_name = workflow_name
   config.allowed_conclusions = allowed_conclusions.split(',').map(&:strip)

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative './app/services/github_checks_verifier'
 require 'octokit'
 


### PR DESCRIPTION
To keep a code style standard in the project, I'd suggest we use Rubocop as a static linter. We can discuss which code style we would like to use and change the `.rubocop.yml`. 

I'm working in a workflow to run rubocop on pull requests as well, but I'll include it in a separate PR.