### PR TITLE
Bump per_page parameter to 100 in check_runs_for_ref call.

### DIFF
--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -21,7 +21,7 @@ class GithubChecksVerifier < ApplicationService
   end
 
   def query_check_status
-    checks = client.check_runs_for_ref(repo, ref, {accept: "application/vnd.github.antiope-preview+json"}).check_runs
+    checks = client.check_runs_for_ref(repo, ref, {per_page: 100, accept: "application/vnd.github.antiope-preview+json"}).check_runs
     p checks # DEBUG
     apply_filters(checks)
   end


### PR DESCRIPTION
This passes the `per_page` parameter to the `check_runs_for_ref` octokit request.

* Mitigates https://github.com/lewagon/wait-on-check-action/issues/40

(Apologies for the poor quality of this PR, I *think* I have a somewhat working testing environment, but I don't know much about ruby or how to contribute properly. All I could do was run the tests and see them pass (?)):

```
➜  app git:(bump-per-page-to-100) ✗ bundle exec rspec
......[#<OpenStruct status="in_progress", conclusion=nil, name="invoking_check">, #<OpenStruct status="completed", conclusion="success", name="check_completed_success">, #<OpenStruct status="completed", conclusion="failure", name="check_completed_failure">, #<OpenStruct status="completed", conclusion="neutral", name="check_completed_neutral">, #<OpenStruct status="completed", conclusion="timed_out", name="check_completed_timed_out">, #<OpenStruct status="completed", conclusion="action_required", name="check_completed_action_required">, #<OpenStruct status="queued", conclusion=nil, name="action_queued">]
...........

Finished in 0.03195 seconds (files took 0.43465 seconds to load)
17 examples, 0 failures
```

(I know this is very basic ruby, but I'm not even sure how to add a test to assert that we're calling the octokit client with the expected `per_page: 100` value!)