### PR TITLE
Use secrets.GITHUB_TOKEN by default as repo-token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   repo-token:
     description: "A GitHub token for the repo"
     required: false
-    default: ""
+    default: "${{ secrets.GITHUB_TOKEN }}"
   wait-interval:
     description: "Seconds to wait between Checks API requests"
     required: false


### PR DESCRIPTION
This will truly make repo-token optional.