### PR TITLE
Revert "Use secrets.GITHUB_TOKEN by default as repo-token"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   repo-token:
     description: "A GitHub token for the repo"
     required: false
-    default: "${{ secrets.GITHUB_TOKEN }}"
+    default: ""
   wait-interval:
     description: "Seconds to wait between Checks API requests"
     required: false


### PR DESCRIPTION
Reverts lewagon/wait-on-check-action#58