### PR TITLE
Use latest ruby/setup-ruby

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ruby/setup-ruby@v1.81.0
+    - uses: ruby/setup-ruby@v1.120.0
       with:
         ruby-version: 2.7 # Not needed with a .ruby-version file
 


### PR DESCRIPTION
I currently have this warning in my CI, which is resolved in the latest version of `ruby/setup-ruby`:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: ruby/setup-ruby, actions/cache, actions/cache
```