### PR TITLE
chore: Update to actions/cache@v3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
           ruby-version: 2.7 # Not needed with a .ruby-version file
 
       - name: Cache Ruby Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         ruby-version: 2.7 # Not needed with a .ruby-version file
 
     - name: Cache Ruby Gems
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.action_path }}
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
Resolves

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: ruby/setup-ruby, actions/cache, actions/cache
```