### PR TITLE
Use latest stable versions for ruby/setup-ruby and actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,12 +42,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ruby/setup-ruby@v1.81.0
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7 # Not needed with a .ruby-version file
 
     - name: Cache Ruby Gems
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.action_path }}
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
👋 Hello, thank you for developing useful actions.

I got some of warnings with this action.

see https://github.com/ruby/rake/actions/runs/4171846990/jobs/7222232175#step:3:37

I bump up to use latest stable versions of internal actions for these warnings.