### PR TITLE
fix(v1.2.0): pin bundler version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ runs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2 # Not needed with a .ruby-version file
+        bundler: 2.4.22
 
     - name: Cache Ruby Gems
       uses: actions/cache@v3


### PR DESCRIPTION
Recently a new version of `bundler` was released causing installation step to fail with below error. Pinning bundler version to the desired one to avoid failures

<img width="1033" alt="image" src="https://github.com/lewagon/wait-on-check-action/assets/43565572/e9eaac8d-4d01-4fe1-9ea8-62511f71d3a4">
