### PR TITLE
Update `actions/cache` to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         ruby-version: 3.2 # Not needed with a .ruby-version file
 
     - name: Cache Ruby Gems
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.action_path }}
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
Update to the newest version 4 of `actions/cache`, which uses Node 20 under the hood.

The old version gives the deprecation warning:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`