### PR TITLE
allows paginating checks

### DIFF
--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -28,7 +28,11 @@ class GithubChecksVerifier < ApplicationService
 
   def query_check_status
     checks = client.check_runs_for_ref(
-      repo, ref, {accept: "application/vnd.github.antiope-preview+json"}
+      repo, ref,
+      {
+        accept: "application/vnd.github.antiope-preview+json",
+        auto_paginate: true
+      }
     ).check_runs
     log_checks(checks, "Checks running on ref:")
 

--- a/app/spec/services/github_checks_verifier_spec.rb
+++ b/app/spec/services/github_checks_verifier_spec.rb
@@ -75,6 +75,25 @@ describe GithubChecksVerifier do
 
       expect(result.map(&:name)).not_to include("invoking_check")
     end
+
+    context "when there are many checks" do
+      it 'handles more than 30 check results' do
+        checks = 35.times.map do |i|
+          OpenStruct.new(
+            name: "check-#{i}",
+            status: 'completed',
+            conclusion: 'success'
+          )
+        end
+
+        mock_response = OpenStruct.new(check_runs: checks)
+        allow(service.config.client).to receive(:check_runs_for_ref)
+                                          .and_return(mock_response)
+
+        result = service.send(:query_check_status)
+        expect(result.length).to eq(35)
+      end
+    end
   end
 
   describe "#fail_if_requested_check_never_run" do


### PR DESCRIPTION
## Context

The current implementation does not paginate checks, so if a suite uses more than 30 checks there is a chance that the specified checks will not be present. This fixes this bug by properly paginating.

API Reference: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
