### PR TITLE
Fix spelling mistakes and add frozen_string_literal comments

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,14 +12,9 @@
   "words": [
     "antiope",
     "bumpversion",
-    "conclussions",
-    "conlusions",
-    "cyecle",
     "doctl",
-    "drprasad",
     "kubeconfig",
     "lewagon",
-    "progapandist",
     "rubocop",
     "yardoc"
   ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,6 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
-
 RSpec/AnyInstance:
   Enabled: false
 
@@ -26,31 +23,13 @@ RSpec/MultipleExpectations:
 RSpec/VerifiedDoubles:
   Enabled: false
 
-Style/BlockDelimiters:
-  Enabled: false
-
 Style/Documentation:
-  Enabled: false
-
-Style/FetchEnvVar:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/OpenStructUse:
   Enabled: false
 
-Style/RaiseArgs:
-  Enabled: false
-
 Style/StringLiterals:
-  Enabled: false
-
-Style/StringLiteralsInInterpolation:
-  Enabled: false
-
-Style/TernaryParentheses:
   Enabled: false
 
 Style/WordArray:

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ As it could be seen in many examples, there's a parameter `wait-interval`, and s
 
 ### Verbose (optional, default: true)
 
-If true, it prints some logs to help understanding the process (checks found, filtered, conclussions, etc.)
+If true, it prints some logs to help understanding the process (checks found, filtered, conclusions, etc.)
 
 ## Auto-pagination
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # action.yml
 name: "Wait on check"
-author: "progapandist"
+author: "lewagon"
 description: "Wait on a certain check to pass for commit"
 inputs:
   allowed-conclusions:

--- a/app/errors/check_conclusion_not_allowed_error.rb
+++ b/app/errors/check_conclusion_not_allowed_error.rb
@@ -3,7 +3,7 @@
 class CheckConclusionNotAllowedError < StandardError
   def initialize(allowed_conclusions)
     msg = "The conclusion of one or more checks were not allowed. Allowed conclusions are: " \
-          "#{allowed_conclusions.join(", ")}. This can be configured with the 'allowed-conclusions' param."
+          "#{allowed_conclusions.join(', ')}. This can be configured with the 'allowed-conclusions' param."
     super(msg)
   end
 end

--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -28,7 +28,7 @@ class GithubChecksVerifier < ApplicationService
 
   def query_check_status
     checks = client.check_runs_for_ref(
-      repo, ref, {accept: "application/vnd.github.antiope-preview+json"}
+      repo, ref, { accept: "application/vnd.github.antiope-preview+json" }
     ).check_runs
     log_checks(checks, "Checks running on ref:")
 
@@ -82,7 +82,7 @@ class GithubChecksVerifier < ApplicationService
   def fail_unless_all_conclusions_allowed(checks)
     return if checks.all? { |check| check_conclusion_allowed(check) }
 
-    raise CheckConclusionNotAllowedError.new(allowed_conclusions)
+    raise CheckConclusionNotAllowedError, allowed_conclusions
   end
 
   def show_checks_conclusion_message(checks)
@@ -98,7 +98,7 @@ class GithubChecksVerifier < ApplicationService
     fail_if_requested_check_never_run(all_checks)
 
     until all_checks_complete(all_checks)
-      plural_part = (all_checks.length > 1) ? "checks aren't" : "check isn't"
+      plural_part = all_checks.length > 1 ? "checks aren't" : "check isn't"
       puts "The requested #{plural_part} complete yet, will check back in #{wait} seconds..."
       sleep(wait)
       all_checks = query_check_status

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -1,17 +1,20 @@
 #!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
 require_relative "app/services/github_checks_verifier"
 require "octokit"
 
-allowed_conclusions = ENV["ALLOWED_CONCLUSIONS"]
-check_name = ENV["CHECK_NAME"]
-check_regexp = ENV["CHECK_REGEXP"]
-ref = ENV["REF"]
-token = ENV["REPO_TOKEN"]
-verbose = ENV["VERBOSE"]
-wait = ENV["WAIT_INTERVAL"]
-workflow_name = ENV["RUNNING_WORKFLOW_NAME"]
+allowed_conclusions = ENV.fetch("ALLOWED_CONCLUSIONS", nil)
+check_name = ENV.fetch("CHECK_NAME", nil)
+check_regexp = ENV.fetch("CHECK_REGEXP", nil)
+ref = ENV.fetch("REF", nil)
+token = ENV.fetch("REPO_TOKEN", nil)
+verbose = ENV.fetch("VERBOSE", nil)
+wait = ENV.fetch("WAIT_INTERVAL", nil)
+workflow_name = ENV.fetch("RUNNING_WORKFLOW_NAME", nil)
 api_endpoint = ENV.fetch("API_ENDPOINT", "")
-ignore_checks = ENV["IGNORE_CHECKS"]
+ignore_checks = ENV.fetch("IGNORE_CHECKS", nil)
 
 GithubChecksVerifier.configure do |config|
   config.allowed_conclusions = allowed_conclusions.split(",").map(&:strip)
@@ -22,7 +25,7 @@ GithubChecksVerifier.configure do |config|
   config.client.api_endpoint = api_endpoint unless /\A[[:space:]]*\z/.match?(api_endpoint)
   config.client.access_token = token
   config.ref = ref
-  config.repo = ENV["GITHUB_REPOSITORY"]
+  config.repo = ENV.fetch("GITHUB_REPOSITORY", nil)
   config.verbose = verbose
   config.wait = wait.to_i
   config.workflow_name = workflow_name

--- a/spec/entrypoint_spec.rb
+++ b/spec/entrypoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe "entrypoint" do

--- a/spec/services/github_checks_verifier_spec.rb
+++ b/spec/services/github_checks_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "ostruct"
 
@@ -21,7 +23,7 @@ describe GithubChecksVerifier do
 
   describe "#wait_for_checks" do
     it "waits until all checks are completed" do
-      cycles = 1 # simulates the method waiting for one cyecle
+      cycles = 1 # simulates the method waiting for one cycle
       allow(service).to receive(:all_checks_complete) do
         (cycles -= 1) && cycles < 0
       end
@@ -84,9 +86,9 @@ describe GithubChecksVerifier do
       allow(service).to receive(:query_check_status).and_return all_checks
 
       expected_msg = "The requested check was never run against this ref, exiting..."
-      expect {
+      expect do
         service.call
-      }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      end.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
     end
   end
 
@@ -100,21 +102,21 @@ describe GithubChecksVerifier do
 
       expected_msg = "The conclusion of one or more checks were not allowed. Allowed conclusions are: " \
                      "success, skipped. This can be configured with the 'allowed-conclusions' param."
-      expect {
+      expect do
         service.call
-      }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      end.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
     end
 
-    it "does not raise an exception if all checks conlusions are allowed" do
+    it "does not raise an exception if all checks conclusions are allowed" do
       all_checks = [
         OpenStruct.new(name: "test", status: "completed", conclusion: "success"),
         OpenStruct.new(name: "test", status: "completed", conclusion: "skipped")
       ]
       allow(service).to receive(:query_check_status).and_return all_checks
 
-      expect {
+      expect do
         service.call
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 


### PR DESCRIPTION
* Adds `frozen_string_literal` comments to each file since only some had them
* Fixes spelling mistakes
* Fixes the `action.yml`'s `author` field which should match the repo name here
* Replaces `ENV[]` with `ENV.fetch`