### PR TITLE
Fix the verbose flag

### DIFF
--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -26,7 +26,7 @@ GithubChecksVerifier.configure do |config|
   config.client.access_token = token
   config.ref = ref
   config.repo = ENV.fetch('GITHUB_REPOSITORY', nil)
-  config.verbose = verbose
+  config.verbose = verbose == 'true'
   config.wait = wait.to_i
   config.workflow_name = workflow_name
 end


### PR DESCRIPTION
In #106 @fallemand pointed out that the verbose flag was not working. Passing `verbose: false` explicitly would still be interpreted as `true`.

The verbose flag was passed as an environment variable and was received as a `string` which are all considered `true` in a boolean context:

```rb
verbose = ENV.fetch('VERBOSE', nil)
```

Instead we can consider `'true'` to be `true` only:

```rb
config.verbose = verbose == 'true'
```
