### PR TITLE
Fix the gems caching and don't install the development group

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,22 +46,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.2 # Not needed with a .ruby-version file
+    - name: Checkout the source code
+      uses: actions/checkout@v4
 
-    - name: Cache Ruby Gems
-      uses: actions/cache@v4
+    - name: Set the ruby version
+      uses: ruby/setup-ruby@v1
       with:
-        path: ${{ github.action_path }}
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gems-
-
-    - name: Bundle Install
-      run: |
-        bundle install --jobs 4 --retry 3
-      working-directory: ${{ github.action_path }}
-      shell: bash
+        ruby-version: 3.2
+        bundler-cache: true
+      env:
+        BUNDLE_WITHOUT: "development"
 
     - run: |
         ruby entrypoint.rb


### PR DESCRIPTION
From #102 and #105 the cache key isn't being set properly and the install is too slow

To fix this this PR:
- Adds an actions/checkout step
- Adds bundler-cache: true to the ruby/setup-ruby step
- Runs bundler with bundler install --without development