### PR TITLE
Use working-directory instead of checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,3 @@
-# action.yml
 name: "Wait on check"
 author: "lewagon"
 description: "Wait on a certain check to pass for commit"
@@ -46,18 +45,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout the source code
-      uses: actions/checkout@v4
-
     - name: Set the ruby version
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
         bundler-cache: true
+        working-directory: ${{ github.action_path }}
       env:
         BUNDLE_PATH: "vendor/bundle"
 
     - run: bundle exec entrypoint.rb
+      working-directory: ${{ github.action_path }}
       shell: bash
       env:
         ALLOWED_CONCLUSIONS: ${{ inputs.allowed-conclusions }}


### PR DESCRIPTION
Swapping in and out of the repo with checkout isn't good practice since affects the state of the repo before the action is invoked. This uses the `working-directory` property instead.