### PR TITLE
fix: exit with non-zero status when check conclusions are disallowed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ AllCops:
 RSpec/ExampleLength:
   Enabled: false
   Max: 10
+
+RSpec/MultipleExpectations:
+  Max: 2

--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -29,7 +29,7 @@ class GithubChecksVerifier < ApplicationService
     wait_for_checks
   rescue CheckNeverRunError, CheckConclusionNotAllowedError, RequiredInputError => e
     puts e.message
-    raise SystemExit, 1
+    exit 1
   end
 
   private

--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -29,7 +29,7 @@ class GithubChecksVerifier < ApplicationService
     wait_for_checks
   rescue CheckNeverRunError, CheckConclusionNotAllowedError, RequiredInputError => e
     puts e.message
-    raise SystemExit
+    raise SystemExit, 1
   end
 
   private

--- a/spec/services/github_checks_verifier_spec.rb
+++ b/spec/services/github_checks_verifier_spec.rb
@@ -22,12 +22,14 @@ describe GithubChecksVerifier do
       service.config.ref = ''
       expected_msg = 'The ref parameter is required but was not provided.'
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
+      expect(service).to have_received(:exit).with(1)
     end
 
     it 'raises an error when the repo-token input is empty' do
       service.config.client.access_token = ''
       expected_msg = 'The repo-token parameter is required but was not provided.'
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
+      expect(service).to have_received(:exit).with(1)
     end
   end
 
@@ -40,6 +42,7 @@ describe GithubChecksVerifier do
     it 'exit with status false if wait_for_checks fails' do
       expected_msg = 'The requested check was never run against this ref, exiting...'
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
+      expect(service).to have_received(:exit).with(1)
     end
   end
 
@@ -118,6 +121,7 @@ describe GithubChecksVerifier do
 
       expected_msg = 'The requested check was never run against this ref, exiting...'
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
+      expect(service).to have_received(:exit).with(1)
     end
 
     context 'when fail_on_no_checks is false' do
@@ -164,6 +168,7 @@ describe GithubChecksVerifier do
 
         expected_msg = 'The requested check was never run against this ref, exiting...'
         expect { service.call }.to output(/#{expected_msg}/).to_stdout
+        expect(service).to have_received(:exit).with(1)
       end
 
       it 'raises an exception when check_name is set and no checks match' do
@@ -176,6 +181,7 @@ describe GithubChecksVerifier do
 
         expected_msg = 'The requested check was never run against this ref, exiting...'
         expect { service.call }.to output(/#{expected_msg}/).to_stdout
+        expect(service).to have_received(:exit).with(1)
       end
     end
   end
@@ -231,6 +237,7 @@ describe GithubChecksVerifier do
 
       expected_msg = 'The requested check was never run against this ref, exiting...'
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
+      expect(service).to have_received(:exit).with(1)
     end
   end
 
@@ -248,19 +255,6 @@ describe GithubChecksVerifier do
                      "success, skipped. This can be configured with the 'allowed-conclusions' param."
 
       expect { service.call }.to output(/#{expected_msg}/).to_stdout
-    end
-
-    it 'exits with status code 1 when a check conclusion is not allowed' do
-      all_checks = [
-        Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'success'),
-        Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'failure')
-      ]
-
-      allow(service).to receive(:query_check_status).and_return all_checks
-      allow(service).to receive(:exit)
-
-      service.call
-
       expect(service).to have_received(:exit).with(1)
     end
 

--- a/spec/services/github_checks_verifier_spec.rb
+++ b/spec/services/github_checks_verifier_spec.rb
@@ -10,32 +10,36 @@ describe GithubChecksVerifier do
 
   before do
     described_class.config.client = Octokit::Client.new
+    described_class.config.client.access_token = '_'
+    described_class.config.ref = '_'
     described_class.config.allowed_conclusions = %w[success skipped]
   end
 
   describe '#inputs' do
+    before { allow(service).to receive(:exit) }
+
     it 'raises an error when the ref input is empty' do
       service.config.ref = ''
       expected_msg = 'The ref parameter is required but was not provided.'
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
 
     it 'raises an error when the repo-token input is empty' do
-      service.config.ref = '_'
       service.config.client.access_token = ''
       expected_msg = 'The repo-token parameter is required but was not provided.'
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
   end
 
   describe '#call' do
-    before { allow(service).to receive(:wait_for_checks).and_raise(CheckNeverRunError) }
+    before do
+      allow(service).to receive(:wait_for_checks).and_raise(CheckNeverRunError)
+      allow(service).to receive(:exit)
+    end
 
     it 'exit with status false if wait_for_checks fails' do
-      service.config.ref = '_'
-      service.config.client.access_token = '_'
       expected_msg = 'The requested check was never run against this ref, exiting...'
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
   end
 
@@ -110,9 +114,10 @@ describe GithubChecksVerifier do
 
       all_checks = []
       allow(service).to receive(:query_check_status).and_return all_checks
+      allow(service).to receive(:exit)
 
       expected_msg = 'The requested check was never run against this ref, exiting...'
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
 
     context 'when fail_on_no_checks is false' do
@@ -147,6 +152,8 @@ describe GithubChecksVerifier do
     end
 
     context 'when fail_on_no_checks is true (default)' do
+      before { allow(service).to receive(:exit) }
+
       it 'raises an exception when check_regexp is set and no checks match' do
         service.config.check_regexp = 'non-matching-regexp'
         service.config.fail_on_no_checks = true
@@ -156,7 +163,7 @@ describe GithubChecksVerifier do
         allow(service).to receive(:query_check_status).and_return all_checks
 
         expected_msg = 'The requested check was never run against this ref, exiting...'
-        expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+        expect { service.call }.to output(/#{expected_msg}/).to_stdout
       end
 
       it 'raises an exception when check_name is set and no checks match' do
@@ -168,17 +175,12 @@ describe GithubChecksVerifier do
         allow(service).to receive(:query_check_status).and_return all_checks
 
         expected_msg = 'The requested check was never run against this ref, exiting...'
-        expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+        expect { service.call }.to output(/#{expected_msg}/).to_stdout
       end
     end
   end
 
   describe '#wait_for_check_discovery' do
-    before do
-      service.config.ref = '_'
-      service.config.client.access_token = '_'
-    end
-
     it 'polls until checks are found within the timeout' do
       service.config.check_name = 'delayed-check'
       service.config.fail_on_no_checks = true
@@ -225,25 +227,27 @@ describe GithubChecksVerifier do
       service.wait = 0
 
       allow(service).to receive(:query_check_status).and_return []
+      allow(service).to receive(:exit)
 
       expected_msg = 'The requested check was never run against this ref, exiting...'
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
   end
 
   describe '#fail_unless_all_conclusions_allowed' do
-    it 'raises an exception if some check conclusion is not allowed' do
+    it 'prints an error message when a check conclusion is not allowed' do
       all_checks = [
         Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'success'),
         Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'failure')
       ]
 
       allow(service).to receive(:query_check_status).and_return all_checks
+      allow(service).to receive(:exit)
 
       expected_msg = 'The conclusion of one or more checks were not allowed. Allowed conclusions are: ' \
                      "success, skipped. This can be configured with the 'allowed-conclusions' param."
 
-      expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
+      expect { service.call }.to output(/#{expected_msg}/).to_stdout
     end
 
     it 'exits with status code 1 when a check conclusion is not allowed' do
@@ -253,8 +257,11 @@ describe GithubChecksVerifier do
       ]
 
       allow(service).to receive(:query_check_status).and_return all_checks
+      allow(service).to receive(:exit)
 
-      expect { service.call }.to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 1)))
+      service.call
+
+      expect(service).to have_received(:exit).with(1)
     end
 
     it 'does not raise an exception if all checks conclusions are allowed' do

--- a/spec/services/github_checks_verifier_spec.rb
+++ b/spec/services/github_checks_verifier_spec.rb
@@ -246,6 +246,17 @@ describe GithubChecksVerifier do
       expect { service.call }.to raise_error(SystemExit).and output(/#{expected_msg}/).to_stdout
     end
 
+    it 'exits with status code 1 when a check conclusion is not allowed' do
+      all_checks = [
+        Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'success'),
+        Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'failure')
+      ]
+
+      allow(service).to receive(:query_check_status).and_return all_checks
+
+      expect { service.call }.to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 1)))
+    end
+
     it 'does not raise an exception if all checks conclusions are allowed' do
       all_checks = [
         Helpers::CheckRun.new(name: 'test', status: 'completed', conclusion: 'success'),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,4 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
-  # SystemExit with non-zero status taints Ruby's process exit code even when
-  # caught by raise_error. Force rspec's own exit code after the suite runs.
-  config.after(:suite) do
-    at_exit { exit(RSpec.configuration.reporter.failed_examples.any? ? 1 : 0) }
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,10 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # SystemExit with non-zero status taints Ruby's process exit code even when
+  # caught by raise_error. Force rspec's own exit code after the suite runs.
+  config.after(:suite) do
+    at_exit { exit(RSpec.configuration.reporter.failed_examples.any? ? 1 : 0) }
+  end
 end


### PR DESCRIPTION
# Pull Request

## Description

`raise SystemExit` in Ruby defaults to exit code 0 (success). When a check has a disallowed conclusion, the action detects it and logs the error, but exits with code 0, so the GitHub Actions step passes silently.

This causes downstream workflows that gate on this action (e.g. deploy pipelines) to proceed even when checks have failed.

Fixes lewagon/wait-on-check-action#145

## Current Behavior

```ruby
  rescue CheckNeverRunError, CheckConclusionNotAllowedError, RequiredInputError => e
    puts e.message
    raise SystemExit  # exit code 0 — step passes
  end
```

## New Behavior

```ruby
  rescue CheckNeverRunError, CheckConclusionNotAllowedError, RequiredInputError => e
    puts e.message
    raise SystemExit, 1  # exit code 1 — step fails
  end
```
