### PR TITLE
Fix case of deduplication across check suites

### DIFF
--- a/app/services/github_checks_verifier.rb
+++ b/app/services/github_checks_verifier.rb
@@ -46,7 +46,17 @@ class GithubChecksVerifier < ApplicationService
     checks = client.check_runs_for_ref(repo, ref, options).check_runs
     log_checks(checks, 'Checks running on ref:')
 
+    checks = keep_latest_per_name(checks) unless wait_for_duplicates
     apply_filters(checks)
+  end
+
+  # The API's `filter=latest` only deduplicates within a single check suite, so a
+  # ref can still carry several runs sharing a name when separate events (e.g. an
+  # edited PR) spawn new suites. Unless we are explicitly waiting for duplicates,
+  # keep only the most recently started run for each name so a stale earlier
+  # attempt can't override a newer one.
+  def keep_latest_per_name(checks)
+    checks.group_by(&:name).map { |_name, runs| runs.max_by { |run| run.started_at.to_s } }
   end
 
   def log_checks(checks, msg)

--- a/spec/services/github_checks_verifier_spec.rb
+++ b/spec/services/github_checks_verifier_spec.rb
@@ -160,6 +160,37 @@ describe GithubChecksVerifier do
     end
   end
 
+  describe 'duplicate names across check suites' do
+    # The real API returns one run per check suite even with filter=latest, so a
+    # ref edited after a failure carries both the stale failure and the newer pass.
+    let(:cross_suite_runs) do
+      [
+        Helpers::CheckRun.new(name: 'lint', status: 'completed', conclusion: 'failure',
+                              started_at: '2026-06-30T13:58:00Z'),
+        Helpers::CheckRun.new(name: 'lint', status: 'completed', conclusion: 'success',
+                              started_at: '2026-06-30T14:07:00Z')
+      ]
+    end
+
+    before do
+      allow(described_class.config.client).to receive(:check_runs_for_ref)
+        .and_return(Helpers::CheckRunsResponse.new(cross_suite_runs))
+      allow(service).to receive(:exit)
+    end
+
+    it 'keeps only the most recently started run per name when disabled' do
+      service.config.wait_for_duplicates = false
+      result = service.send(:query_check_status)
+      expect(result.map(&:conclusion)).to eq(['success'])
+    end
+
+    it 'does not fail on a stale earlier failure superseded by a newer pass' do
+      service.config.wait_for_duplicates = false
+      with_captured_stdout { service.call }
+      expect(service).not_to have_received(:exit)
+    end
+  end
+
   describe '#fail_if_requested_check_never_run' do
     it 'raises an exception if check_name is not empty and all_checks is' do
       service.config.check_name = 'test'

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -5,7 +5,7 @@ require 'json'
 module Helpers
   SAMPLE_RESPONSES_BASE_PATH = 'spec/github_api_sample_responses/'
 
-  CheckRun = Struct.new(:status, :conclusion, :name)
+  CheckRun = Struct.new(:status, :conclusion, :name, :started_at)
   CheckRunsResponse = Struct.new(:check_runs)
 
   def load_json_sample(file_name)


### PR DESCRIPTION
# Pull Request

## Description

`wait-on-check-action` requires every check run matching a name to have an allowed conclusion. When `wait-for-duplicates` is disabled (the default), it relies on the GitHub API's `filter=latest` to surface only the most recent run per check name. But filter=latest only deduplicates **within a single check suite** — it does not collapse runs across suites. When separate events on the same SHA spawn new suites (most commonly a PR `edited` event re-triggering a workflow such as a PR-title validator), the ref ends up carrying both the stale earlier run and the newer one under the same name. A stale failure then fails the wait even though the latest run for that name succeeded, making the result non-deterministic.

This adds a client-side deduplication step: unless `wait-for-duplicates` is enabled, keep only the most recently started run for each check name before evaluating conclusions. This matches what the README already documents the default to do ("only the most recent run for a given name is considered").

## Current Behavior

```code
# A PR opened with a bad title fails "Validate PR Title", then the title is
# edited (same SHA), spawning a new suite whose run succeeds. Both runs remain
# on the ref. The API returns both even with filter=latest:

Validate PR Title / Validate PR Title  completed  (failure)   # stale, suite A
Validate PR Title / Validate PR Title  completed  (success)   # latest, suite B

# => "The conclusion of one or more checks were not allowed", exit 1
```

## New Behavior

```code
# Runs are grouped by name and only the most recently started one is kept:

Validate PR Title / Validate PR Title  completed  (success)   # latest, suite B

# => the stale failure is ignored; the action passes.
# (wait-for-duplicates: true is unchanged — it still requires every run to pass.)
```
