### PR TITLE
feat: make bundler cache configurable via action input

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jobs:
 | `api-endpoint`             | Custom GitHub API endpoint (for GHE)                                      | `https://github.mycompany.com/api/v3` | -                 |
 | `check-name`               | Specific check name to wait for                                           | `"Run tests"`                         | -                 |
 | `check-regexp`             | Filter checks using regex pattern                                         | `"test-.*"`                           | -                 |
+| `bundler-cache`            | Enable Bundler cache in `ruby/setup-ruby`                                 | `true`/`false`                         | `true`            |
 | `fail-on-no-checks`        | Fail the action if no checks match the check-name or check-regexp filters | `true`                                | `true`            |
 | `ignore-checks`            | Comma-separated list of checks to ignore                                  | `optional-lint,coverage-report`       | -                 |
 | `running-workflow-name`    | Name of current workflow (to exclude from waiting)                        | `"Deploy"`                            | -                 |

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ jobs:
 | -------------------------- | ------------------------------------------------------------------------- | ------------------------------------- | ----------------- |
 | `allowed-conclusions`      | Comma-separated list of acceptable conclusions                            | `success,skipped`                     | `success,skipped` |
 | `api-endpoint`             | Custom GitHub API endpoint (for GHE)                                      | `https://github.mycompany.com/api/v3` | -                 |
+| `bundler-cache`            | Enable Bundler cache in `ruby/setup-ruby`                                 | `true`                                | `true`            |
 | `check-name`               | Specific check name to wait for                                           | `"Run tests"`                         | -                 |
 | `check-regexp`             | Filter checks using regex pattern                                         | `"test-.*"`                           | -                 |
-| `bundler-cache`            | Enable Bundler cache in `ruby/setup-ruby`                                 | `true`/`false`                         | `true`            |
+| `checks-discovery-timeout` | Seconds to wait for checks to be discovered                               | `60`                                  | `60`              |
 | `fail-on-no-checks`        | Fail the action if no checks match the check-name or check-regexp filters | `true`                                | `true`            |
 | `ignore-checks`            | Comma-separated list of checks to ignore                                  | `optional-lint,coverage-report`       | -                 |
 | `running-workflow-name`    | Name of current workflow (to exclude from waiting)                        | `"Deploy"`                            | -                 |
 | `verbose`                  | Print detailed logs                                                       | `true`                                | `true`            |
 | `wait-interval`            | Seconds between API requests                                              | `10`                                  | `10`              |
-| `checks-discovery-timeout` | Seconds to wait for checks to be discovered                               | `60`                                  | `60`              |
 | `wait-for-duplicates`      | Require every check with a duplicate name to succeed                      | `false`                               | `false`           |
 
 ## Usage examples

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: "Require every check with a duplicate name to succeed"
     required: false
     default: "false"
+  bundler-cache:
+    description: "Enable Bundler cache in ruby/setup-ruby"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -60,7 +64,7 @@ runs:
       uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64
       with:
         ruby-version: 3.2
-        bundler-cache: true
+        bundler-cache: ${{ inputs.bundler-cache }}
         working-directory: ${{ github.action_path }}
       env:
         BUNDLE_PATH: "vendor/bundle"


### PR DESCRIPTION
# Pull Request

## Description
Add optional bundler-cache input (default: true) and pass it to ruby/setup-ruby. Bundler cache is currently always on, which creates ~10 MB cache entries for each feature branch run. With limited cache quota, this adds up quickly and reduces space for other higher-impact caches.

This update lets users turn off Bundler caching or manage caching themselves when needed (for example, on non-main branches), while preserving the default behavior.

## Current Behavior
Bundler caching is always enabled via ruby/setup-ruby, so every run creates/restores a Bundler cache. This can generate cache entries for each feature branch.

## New Behavior
Bundler caching is configurable through the new bundler-cache input. It defaults to true (no breaking change), but users can set it to false or apply branch-based logic (for example, enable only on main).
