### PR TITLE
fix: install gems if cache is false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         bundler-cache: ${{ inputs.bundler-cache }}
         working-directory: ${{ github.action_path }}
       env:
-        BUNDLE_PATH: "vendor/bundle"
+        BUNDLE_PATH: "${{ github.action_path }}/vendor/bundle"
 
     - name: Install dependencies without caching
       if: inputs.bundler-cache == 'false'
@@ -75,7 +75,7 @@ runs:
       working-directory: ${{ github.action_path }}
       shell: bash
       env:
-        BUNDLE_PATH: "vendor/bundle"
+        BUNDLE_PATH: "${{ github.action_path }}/vendor/bundle"
 
     - run: bundle exec entrypoint.rb
       working-directory: ${{ github.action_path }}
@@ -94,7 +94,7 @@ runs:
         FAIL_ON_NO_CHECKS: ${{ inputs.fail-on-no-checks }}
         CHECKS_DISCOVERY_TIMEOUT: ${{ inputs.checks-discovery-timeout }}
         WAIT_FOR_DUPLICATES: ${{ inputs.wait-for-duplicates }}
-        BUNDLE_PATH: "vendor/bundle"
+        BUNDLE_PATH: "${{ github.action_path }}/vendor/bundle"
 
 branding:
   icon: "check-circle"

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,14 @@ runs:
       env:
         BUNDLE_PATH: "vendor/bundle"
 
+    - name: Install dependencies without caching
+      if: inputs.bundler-cache == 'false'
+      run: bundle install
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      env:
+        BUNDLE_PATH: "vendor/bundle"
+
     - run: bundle exec entrypoint.rb
       working-directory: ${{ github.action_path }}
       shell: bash
@@ -86,6 +94,7 @@ runs:
         FAIL_ON_NO_CHECKS: ${{ inputs.fail-on-no-checks }}
         CHECKS_DISCOVERY_TIMEOUT: ${{ inputs.checks-discovery-timeout }}
         WAIT_FOR_DUPLICATES: ${{ inputs.wait-for-duplicates }}
+        BUNDLE_PATH: "vendor/bundle"
 
 branding:
   icon: "check-circle"


### PR DESCRIPTION
# Pull Request

## Description
Since #160 was introduced, gems are not being installed when `bundler-cache: false`. ruby/setup-ruby only runs bundle install as part of its cache handling, so setting `bundler-cache: false` skips gem installation entirely and the action fails.

This adds a fallback bundle install step when caching is disabled, and sets `BUNDLE_PATH` on the entrypoint step so it finds the installed gems.

## Current Behavior
With `bundler-cache: false`, ruby/setup-ruby skips running bundle install, so gems are never installed and the action fails when it reaches `bundle exec entrypoint.rb`.

## New Behavior
When `bundler-cache: false`, an explicit bundle install step runs so gems are always installed (just not cached). `BUNDLE_PATH` is also set on the entrypoint step so it finds those gems.
